### PR TITLE
Add guidelines for repository contributors

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+Outlines guidelines for contributing, including coding standards, testing requirements, and how to submit pull requests.
+
+
+# Development
+To develop 
+```bash
+uv self update
+uv python install 3.14
+uv venv
+. .venv/Scripts/activate
+uv pip install -r pyproject.toml
+uv sync
+uv pip install -e .
+uv run src/data_preprocessor
+```
+
+


### PR DESCRIPTION
Add guidelines for repository contributors. See https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors